### PR TITLE
Created app.json and added Ruby buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "name": "ruby-simple-server",
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}


### PR DESCRIPTION
The `bundle: command not found` error happens when `ruby-simple-server` is deployed without the Ruby buildpack.

<img width="1180" alt="Screen Shot 2023-06-12 at 12 18 13 PM" src="https://github.com/sreeram-venkitesh/ruby-simple-server/assets/40194401/c7d93b5e-19ac-4b2f-8690-4e9997e2a39b">
